### PR TITLE
Add proper define for screen size

### DIFF
--- a/o2_analyzer2.ino
+++ b/o2_analyzer2.ino
@@ -25,6 +25,8 @@
 #include <Adafruit_ADS1015.h>
 #include <EEPROM.h>
 #include <RunningAverage.h>
+#define SCREEN_WIDTH 128 // OLED display width, in pixels
+#define SCREEN_HEIGHT 64 // OLED display height, in pixels
 
 #define RA_SIZE 20
 RunningAverage RA(RA_SIZE);


### PR DESCRIPTION
Define settings added for OLED display size in driver per Adafruit examples, https://github.com/adafruit/Adafruit_SSD1306/blob/master/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino